### PR TITLE
Revert "Return the ignored error"

### DIFF
--- a/gssapi.go
+++ b/gssapi.go
@@ -242,7 +242,7 @@ func initClientContext(c *GSSAPIContext, service string, inputToken []byte) erro
 	c.token = token.Bytes()
 	c.contextId = contextId
 	c.availFlags = outputRetFlags
-	return err
+	return nil
 }
 
 // Wrap calls GSS_Wrap

--- a/gssapi.go
+++ b/gssapi.go
@@ -239,14 +239,10 @@ func initClientContext(c *GSSAPIContext, service string, inputToken []byte) erro
 		_inputToken)
 	defer token.Release()
 
-	if err != nil {
-		return err
-	}
-
 	c.token = token.Bytes()
 	c.contextId = contextId
 	c.availFlags = outputRetFlags
-	return nil
+	return err
 }
 
 // Wrap calls GSS_Wrap

--- a/sasl_gssapi_test.go
+++ b/sasl_gssapi_test.go
@@ -16,6 +16,9 @@ func TestGSSAPIMechanism(t *testing.T) {
 	client := NewSaslClient("localhost", mechanism)
 	client.GetConfig().AuthorizationID = "username"
 	client.Start()
+	for _, input := range [][]byte{[]byte("Ahjdskahdjkaw12kadlsj"), []byte("0"), nil} {
+		client.Step(input)
+	}
 
 	if client.Complete() {
 		t.Fatal("Client can't be complete")


### PR DESCRIPTION
Reverts beltran/gosasl#18 @EugeneChung this is actually breaking some dependencies like gohive, see for example the tests running [here](https://github.com/beltran/gohive/pull/95). I'll revert this for now until it's more clear what's happening.